### PR TITLE
Add basic listing endpoints and payment webhook

### DIFF
--- a/src/main/java/com/fightingkorea/platform/domain/order/controller/PaymentController.java
+++ b/src/main/java/com/fightingkorea/platform/domain/order/controller/PaymentController.java
@@ -1,0 +1,21 @@
+package com.fightingkorea.platform.domain.order.controller;
+
+import com.fightingkorea.platform.domain.order.dto.VideoPurchaseRequest;
+import com.fightingkorea.platform.domain.order.entity.Order;
+import com.fightingkorea.platform.domain.order.service.PurchaseService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PurchaseService purchaseService;
+
+    // 결제 완료 처리 엔드포인트
+    @PostMapping("/complete")
+    public Order completePayment(@RequestBody VideoPurchaseRequest request) {
+        return purchaseService.purchaseVideo(request);
+    }
+}

--- a/src/main/java/com/fightingkorea/platform/domain/trainer/controller/TrainerController.java
+++ b/src/main/java/com/fightingkorea/platform/domain/trainer/controller/TrainerController.java
@@ -8,6 +8,9 @@ import com.fightingkorea.platform.domain.trainer.dto.TrainerUpdateRequest;
 import com.fightingkorea.platform.domain.trainer.service.TrainerService;
 import com.fightingkorea.platform.global.UserUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -28,6 +31,12 @@ public class TrainerController {
     @GetMapping("/me")
     public TrainerResponse getTrainer() {
         return trainerService.getTrainer(UserUtil.getTrainerId());
+    }
+
+    // 트레이너 목록 조회
+    @GetMapping
+    public PageImpl<TrainerResponse> getTrainers(@PageableDefault(size = 20) Pageable pageable) {
+        return trainerService.getTrainers(pageable);
     }
 
     // 트레이너 정보 수정

--- a/src/main/java/com/fightingkorea/platform/domain/user/controller/UserController.java
+++ b/src/main/java/com/fightingkorea/platform/domain/user/controller/UserController.java
@@ -123,6 +123,14 @@ public class UserController {
         return videoService.getPurchasedVideoList(UserUtil.getUserId(), pageable);
     }
 
+    // 현재 로그인한 사용자의 강의 구매 목록 조회 (사양 경로)
+    @GetMapping("/me/purchases")
+    public Page<UserVideoResponse> getMyPurchasedVideos(
+            @PageableDefault(size = 10, sort = "purchasedAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return videoService.getPurchasedVideoList(UserUtil.getUserId(), pageable);
+    }
+
 
     // 강의 구매 내역을 삭제하는 메서드
     @DeleteMapping("/{user-video}")

--- a/src/main/java/com/fightingkorea/platform/domain/video/controller/VideoController.java
+++ b/src/main/java/com/fightingkorea/platform/domain/video/controller/VideoController.java
@@ -6,6 +6,9 @@ import com.fightingkorea.platform.domain.video.dto.VideoUploadMultipartRequest;
 import com.fightingkorea.platform.domain.video.service.VideoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -20,6 +23,12 @@ public class VideoController {
     @PostMapping
     public VideoResponse uploadVideo(@RequestPart @Validated VideoUploadMultipartRequest req, @RequestPart MultipartFile file){
         return videoService.uploadVideoMultipart(req, file);
+    }
+
+    // 비디오 목록 조회
+    @GetMapping
+    public Page<VideoResponse> getVideos(@PageableDefault(size = 20) Pageable pageable) {
+        return videoService.getVideos(pageable);
     }
 
     // 비디오 수정

--- a/src/main/java/com/fightingkorea/platform/domain/video/service/Impl/VideoServiceImpl.java
+++ b/src/main/java/com/fightingkorea/platform/domain/video/service/Impl/VideoServiceImpl.java
@@ -40,6 +40,12 @@ public class VideoServiceImpl implements VideoService {
     
 
     @Override
+    @Transactional(readOnly = true)
+    public Page<VideoResponse> getVideos(Pageable pageable) {
+        return videoRepository.findAll(pageable).map(this::toDtoWithNoLink);
+    }
+
+    @Override
     public VideoResponse updateVideo(Long videoId, VideoUpdateRequest req) {
         Video video = videoRepository.findVideoByVideoId(videoId)
                 .orElseThrow(VideoNotExistsException::new);

--- a/src/main/java/com/fightingkorea/platform/domain/video/service/VideoService.java
+++ b/src/main/java/com/fightingkorea/platform/domain/video/service/VideoService.java
@@ -6,6 +6,9 @@ import org.springframework.data.domain.Pageable;
 
 public interface VideoService {
 
+
+    // 비디오 목록 조회 (페이징)
+    Page<VideoResponse> getVideos(Pageable pageable);
     
 
     VideoResponse updateVideo(Long videoId, VideoUpdateRequest req);


### PR DESCRIPTION
## Summary
- add paginated video listing endpoint
- expose trainer listing endpoint
- support fetching current user's purchases
- implement simple payment completion controller

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c4cf1a3c8322b8a94aba779ac87d