### PR TITLE
feat: add video and trainer list filtering

### DIFF
--- a/src/main/java/com/fightingkorea/platform/domain/trainer/controller/TrainerController.java
+++ b/src/main/java/com/fightingkorea/platform/domain/trainer/controller/TrainerController.java
@@ -1,16 +1,13 @@
 package com.fightingkorea.platform.domain.trainer.controller;
 
 import com.fightingkorea.platform.domain.earning.service.EarningService;
-import com.fightingkorea.platform.domain.trainer.dto.TrainerRegisterRequest;
-import com.fightingkorea.platform.domain.trainer.dto.TrainerRegisterResponse;
-import com.fightingkorea.platform.domain.trainer.dto.TrainerResponse;
-import com.fightingkorea.platform.domain.trainer.dto.TrainerUpdateRequest;
+import com.fightingkorea.platform.domain.trainer.dto.*;
 import com.fightingkorea.platform.domain.trainer.service.TrainerService;
 import com.fightingkorea.platform.global.UserUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -35,8 +32,29 @@ public class TrainerController {
 
     // 트레이너 목록 조회
     @GetMapping
-    public PageImpl<TrainerResponse> getTrainers(@PageableDefault(size = 20) Pageable pageable) {
-        return trainerService.getTrainers(pageable);
+    public PageImpl<TrainerResponse> getTrainers(
+            @RequestParam(required = false) Integer page,
+            @RequestParam(required = false) Integer perPage,
+            @RequestParam(required = false) Long specialtyId,
+            @RequestParam(required = false) String region,
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false, defaultValue = "joinDate") String sortBy,
+            @RequestParam(required = false, defaultValue = "desc") String sortOrder
+    ) {
+        int p = (page == null || page < 1) ? 0 : page - 1;
+        int size = (perPage == null) ? 20 : Math.min(perPage, 100);
+
+        Pageable pageable = PageRequest.of(p, size);
+
+        TrainerSearchRequest request = TrainerSearchRequest.builder()
+                .specialtyId(specialtyId)
+                .region(region)
+                .search(search)
+                .sortBy(sortBy)
+                .sortOrder(sortOrder)
+                .build();
+
+        return trainerService.getTrainers(request, pageable);
     }
 
     // 트레이너 정보 수정

--- a/src/main/java/com/fightingkorea/platform/domain/trainer/dto/TrainerSearchRequest.java
+++ b/src/main/java/com/fightingkorea/platform/domain/trainer/dto/TrainerSearchRequest.java
@@ -1,0 +1,18 @@
+package com.fightingkorea.platform.domain.trainer.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TrainerSearchRequest {
+    private Long specialtyId;
+    private String region;
+    private String search;
+    private String sortBy;
+    private String sortOrder;
+}

--- a/src/main/java/com/fightingkorea/platform/domain/trainer/repository/CustomTrainerRepository.java
+++ b/src/main/java/com/fightingkorea/platform/domain/trainer/repository/CustomTrainerRepository.java
@@ -1,9 +1,10 @@
 package com.fightingkorea.platform.domain.trainer.repository;
 
 import com.fightingkorea.platform.domain.trainer.dto.TrainerResponse;
+import com.fightingkorea.platform.domain.trainer.dto.TrainerSearchRequest;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomTrainerRepository {
-    PageImpl<TrainerResponse> findBySomeCondition(Pageable pageable);
+    PageImpl<TrainerResponse> search(TrainerSearchRequest request, Pageable pageable);
 }

--- a/src/main/java/com/fightingkorea/platform/domain/trainer/repository/impl/CustomTrainerRepositoryImpl.java
+++ b/src/main/java/com/fightingkorea/platform/domain/trainer/repository/impl/CustomTrainerRepositoryImpl.java
@@ -1,10 +1,16 @@
 package com.fightingkorea.platform.domain.trainer.repository.impl;
 
 import com.fightingkorea.platform.domain.trainer.dto.TrainerResponse;
+import com.fightingkorea.platform.domain.trainer.dto.TrainerSearchRequest;
 import com.fightingkorea.platform.domain.trainer.entity.QTrainer;
+import com.fightingkorea.platform.domain.trainer.entity.QTrainerSpecialty;
 import com.fightingkorea.platform.domain.trainer.repository.CustomTrainerRepository;
 import com.fightingkorea.platform.domain.user.dto.UserResponse;
 import com.fightingkorea.platform.domain.user.entity.QUser;
+import com.fightingkorea.platform.domain.video.entity.QVideo;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -22,9 +28,35 @@ public class CustomTrainerRepositoryImpl implements CustomTrainerRepository {
 
     QTrainer trainer = QTrainer.trainer;
     QUser user = QUser.user;
+    QTrainerSpecialty trainerSpecialty = QTrainerSpecialty.trainerSpecialty;
+    QVideo video = QVideo.video;
 
     @Override
-    public PageImpl<TrainerResponse> findBySomeCondition(Pageable pageable) {
+    public PageImpl<TrainerResponse> search(TrainerSearchRequest request, Pageable pageable) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(user.isActive.eq(true));
+
+        if (request.getRegion() != null) {
+            builder.and(user.region.eq(request.getRegion()));
+        }
+
+        if (request.getSearch() != null) {
+            builder.and(user.nickname.containsIgnoreCase(request.getSearch())
+                    .or(trainer.bio.containsIgnoreCase(request.getSearch())));
+        }
+
+        if (request.getSpecialtyId() != null) {
+            builder.and(trainerSpecialty.specialtyId.eq(request.getSpecialtyId()));
+        }
+
+        Order order = "asc".equalsIgnoreCase(request.getSortOrder()) ? Order.ASC : Order.DESC;
+        OrderSpecifier<?> orderSpecifier;
+        if ("videoCount".equalsIgnoreCase(request.getSortBy())) {
+            orderSpecifier = new OrderSpecifier<>(order, video.count());
+        } else {
+            orderSpecifier = new OrderSpecifier<>(order, user.createdAt);
+        }
+
         List<TrainerResponse> contents = queryFactory
                 .select(Projections.constructor(TrainerResponse.class,
                         trainer.trainerId,
@@ -34,24 +66,30 @@ public class CustomTrainerRepositoryImpl implements CustomTrainerRepository {
                         trainer.automaticSettlement,
                         trainer.charge,
                         Projections.constructor(UserResponse.class,
-                                trainer.user.userId,
-                                trainer.user.nickname,
-                                trainer.user.role,
-                                trainer.user.createdAt
+                                user.userId,
+                                user.nickname,
+                                user.role,
+                                user.createdAt
                         )
                 ))
                 .from(trainer)
                 .join(trainer.user, user)
-                .where(trainer.user.isActive.eq(true))
-                .orderBy(trainer.user.createdAt.desc())
-                .offset((long) pageable.getPageNumber() * pageable.getPageSize())
+                .leftJoin(trainerSpecialty).on(trainerSpecialty.trainerId.eq(trainer.trainerId))
+                .leftJoin(trainer.videos, video)
+                .where(builder)
+                .groupBy(trainer.trainerId)
+                .orderBy(orderSpecifier)
+                .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
         Long total = queryFactory
-                .select(trainer.count())
+                .select(trainer.trainerId.countDistinct())
                 .from(trainer)
-                .where(trainer.user.isActive.eq(true))
+                .join(trainer.user, user)
+                .leftJoin(trainerSpecialty).on(trainerSpecialty.trainerId.eq(trainer.trainerId))
+                .leftJoin(trainer.videos, video)
+                .where(builder)
                 .fetchOne();
 
         return new PageImpl<>(contents, pageable, total);

--- a/src/main/java/com/fightingkorea/platform/domain/trainer/service/TrainerService.java
+++ b/src/main/java/com/fightingkorea/platform/domain/trainer/service/TrainerService.java
@@ -1,9 +1,6 @@
 package com.fightingkorea.platform.domain.trainer.service;
 
-import com.fightingkorea.platform.domain.trainer.dto.TrainerRegisterRequest;
-import com.fightingkorea.platform.domain.trainer.dto.TrainerRegisterResponse;
-import com.fightingkorea.platform.domain.trainer.dto.TrainerResponse;
-import com.fightingkorea.platform.domain.trainer.dto.TrainerUpdateRequest;
+import com.fightingkorea.platform.domain.trainer.dto.*;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
@@ -12,7 +9,7 @@ public interface TrainerService {
 
     TrainerResponse getTrainer(Long trainerId);
 
-    PageImpl<TrainerResponse> getTrainers(Pageable pageable);
+    PageImpl<TrainerResponse> getTrainers(TrainerSearchRequest request, Pageable pageable);
 
     void updateTrainer(TrainerUpdateRequest trainerUpdateRequest);
 }

--- a/src/main/java/com/fightingkorea/platform/domain/trainer/service/impl/TrainerServiceImpl.java
+++ b/src/main/java/com/fightingkorea/platform/domain/trainer/service/impl/TrainerServiceImpl.java
@@ -1,9 +1,6 @@
 package com.fightingkorea.platform.domain.trainer.service.impl;
 
-import com.fightingkorea.platform.domain.trainer.dto.TrainerRegisterRequest;
-import com.fightingkorea.platform.domain.trainer.dto.TrainerRegisterResponse;
-import com.fightingkorea.platform.domain.trainer.dto.TrainerResponse;
-import com.fightingkorea.platform.domain.trainer.dto.TrainerUpdateRequest;
+import com.fightingkorea.platform.domain.trainer.dto.*;
 import com.fightingkorea.platform.domain.trainer.entity.Trainer;
 import com.fightingkorea.platform.domain.trainer.entity.TrainerSpecialty;
 import com.fightingkorea.platform.domain.trainer.exception.TrainerNotFoundException;
@@ -88,10 +85,10 @@ public class TrainerServiceImpl implements TrainerService {
     // 페이징된 트레이너 리스트 조회
     @Transactional(readOnly = true)
     @Override
-    public PageImpl<TrainerResponse> getTrainers(Pageable pageable) {
+    public PageImpl<TrainerResponse> getTrainers(TrainerSearchRequest request, Pageable pageable) {
         log.info("트레이너 목록 조회 요청, 페이지 번호: {}, 페이지 크기: {}", pageable.getPageNumber(), pageable.getPageSize());
 
-        PageImpl<TrainerResponse> result = trainerRepository.findBySomeCondition(pageable);
+        PageImpl<TrainerResponse> result = trainerRepository.search(request, pageable);
 
         log.info("트레이너 목록 조회 완료, 조회 수: {}", result.getNumberOfElements());
 

--- a/src/main/java/com/fightingkorea/platform/domain/video/dto/VideoSearchRequest.java
+++ b/src/main/java/com/fightingkorea/platform/domain/video/dto/VideoSearchRequest.java
@@ -1,0 +1,21 @@
+package com.fightingkorea.platform.domain.video.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VideoSearchRequest {
+    private Long categoryId;
+    private Long trainerId;
+    private String search;
+    private Integer minPrice;
+    private Integer maxPrice;
+}
+

--- a/src/main/java/com/fightingkorea/platform/domain/video/entity/Video.java
+++ b/src/main/java/com/fightingkorea/platform/domain/video/entity/Video.java
@@ -1,12 +1,13 @@
 package com.fightingkorea.platform.domain.video.entity;
 
 import com.fightingkorea.platform.domain.trainer.entity.Trainer;
-
 import jakarta.persistence.*;
-
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
 
 @Entity
 @Table(name = "videos")
@@ -46,6 +47,9 @@ public class Video {
 
     @Column
     private Integer likesCount; // 좋아요
+
+    @OneToMany(mappedBy = "video", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<VideoCategory> videoCategories = new ArrayList<>();
 
     public static Video createVideoFromMultipart(com.fightingkorea.platform.domain.video.dto.VideoUploadMultipartRequest req, Trainer trainer, String s3Key) {
         return Video

--- a/src/main/java/com/fightingkorea/platform/domain/video/repository/VideoRepository.java
+++ b/src/main/java/com/fightingkorea/platform/domain/video/repository/VideoRepository.java
@@ -2,10 +2,11 @@ package com.fightingkorea.platform.domain.video.repository;
 
 import com.fightingkorea.platform.domain.video.entity.Video;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.Optional;
 
-public interface VideoRepository extends JpaRepository<Video, Long> {
+public interface VideoRepository extends JpaRepository<Video, Long>, JpaSpecificationExecutor<Video> {
 
     Boolean existsByTitle(String title);
 

--- a/src/main/java/com/fightingkorea/platform/domain/video/service/Impl/VideoServiceImpl.java
+++ b/src/main/java/com/fightingkorea/platform/domain/video/service/Impl/VideoServiceImpl.java
@@ -6,6 +6,7 @@ import com.fightingkorea.platform.domain.trainer.repository.TrainerRepository;
 import com.fightingkorea.platform.domain.video.dto.*;
 import com.fightingkorea.platform.domain.video.entity.UserVideo;
 import com.fightingkorea.platform.domain.video.entity.Video;
+import com.fightingkorea.platform.domain.video.entity.VideoCategory;
 import com.fightingkorea.platform.domain.video.exception.*;
 import com.fightingkorea.platform.domain.video.repository.UserVideoRepository;
 import com.fightingkorea.platform.domain.video.repository.VideoRepository;
@@ -18,6 +19,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -41,8 +45,37 @@ public class VideoServiceImpl implements VideoService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<VideoResponse> getVideos(Pageable pageable) {
-        return videoRepository.findAll(pageable).map(this::toDtoWithNoLink);
+    public Page<VideoResponse> getVideos(VideoSearchRequest request, Pageable pageable) {
+        Specification<Video> spec = Specification.where(null);
+
+        if (request.getTrainerId() != null) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("trainer").get("trainerId"), request.getTrainerId()));
+        }
+
+        if (request.getSearch() != null && !request.getSearch().isBlank()) {
+            String like = "%" + request.getSearch() + "%";
+            spec = spec.and((root, query, cb) -> cb.or(
+                    cb.like(root.get("title"), like),
+                    cb.like(root.get("description"), like)
+            ));
+        }
+
+        if (request.getMinPrice() != null) {
+            spec = spec.and((root, query, cb) -> cb.greaterThanOrEqualTo(root.get("price"), request.getMinPrice()));
+        }
+
+        if (request.getMaxPrice() != null) {
+            spec = spec.and((root, query, cb) -> cb.lessThanOrEqualTo(root.get("price"), request.getMaxPrice()));
+        }
+
+        if (request.getCategoryId() != null) {
+            spec = spec.and((root, query, cb) -> {
+                Join<Video, VideoCategory> join = root.join("videoCategories", JoinType.INNER);
+                return cb.equal(join.get("categoryId"), request.getCategoryId());
+            });
+        }
+
+        return videoRepository.findAll(spec, pageable).map(this::toDtoWithNoLink);
     }
 
     @Override

--- a/src/main/java/com/fightingkorea/platform/domain/video/service/VideoService.java
+++ b/src/main/java/com/fightingkorea/platform/domain/video/service/VideoService.java
@@ -7,8 +7,8 @@ import org.springframework.data.domain.Pageable;
 public interface VideoService {
 
 
-    // 비디오 목록 조회 (페이징)
-    Page<VideoResponse> getVideos(Pageable pageable);
+    // 비디오 목록 조회 (필터링 및 페이징)
+    Page<VideoResponse> getVideos(VideoSearchRequest request, Pageable pageable);
     
 
     VideoResponse updateVideo(Long videoId, VideoUpdateRequest req);


### PR DESCRIPTION
## Summary
- support flexible filtering and sorting for video list API
- add TrainerSearchRequest and enhance /api/trainers to filter by specialty, region, search term, and sort order
- implement QueryDSL repository logic for trainer search with dynamic criteria

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c77dd0008322a87700baeb1cce7d