### PR TITLE
feat: add video and trainer list filtering

### DIFF
--- a/src/main/java/com/fightingkorea/platform/domain/trainer/controller/TrainerController.java
+++ b/src/main/java/com/fightingkorea/platform/domain/trainer/controller/TrainerController.java
@@ -1,16 +1,18 @@
 package com.fightingkorea.platform.domain.trainer.controller;
 
 import com.fightingkorea.platform.domain.earning.service.EarningService;
-import com.fightingkorea.platform.domain.trainer.dto.TrainerRegisterRequest;
-import com.fightingkorea.platform.domain.trainer.dto.TrainerRegisterResponse;
-import com.fightingkorea.platform.domain.trainer.dto.TrainerResponse;
-import com.fightingkorea.platform.domain.trainer.dto.TrainerUpdateRequest;
+import com.fightingkorea.platform.domain.trainer.dto.*;
 import com.fightingkorea.platform.domain.trainer.service.TrainerService;
+import com.fightingkorea.platform.domain.video.dto.VideoResponse;
+import com.fightingkorea.platform.domain.video.dto.VideoSearchRequest;
+import com.fightingkorea.platform.domain.video.service.VideoService;
 import com.fightingkorea.platform.global.UserUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
+import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,6 +22,7 @@ public class TrainerController {
 
     private final TrainerService trainerService;
     private final EarningService earningService;
+    private final VideoService videoService;
 
     // 트레이너 등록
     @PostMapping("/register")
@@ -35,8 +38,53 @@ public class TrainerController {
 
     // 트레이너 목록 조회
     @GetMapping
-    public PageImpl<TrainerResponse> getTrainers(@PageableDefault(size = 20) Pageable pageable) {
-        return trainerService.getTrainers(pageable);
+    public PageImpl<TrainerResponse> getTrainers(
+            @RequestParam(required = false) Integer page,
+            @RequestParam(required = false) Integer perPage,
+            @RequestParam(required = false) Long specialtyId,
+            @RequestParam(required = false) String region,
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false, defaultValue = "joinDate") String sortBy,
+            @RequestParam(required = false, defaultValue = "desc") String sortOrder
+    ) {
+        int p = (page == null || page < 1) ? 0 : page - 1;
+        int size = (perPage == null) ? 20 : Math.min(perPage, 100);
+
+        Pageable pageable = PageRequest.of(p, size);
+
+        TrainerSearchRequest request = TrainerSearchRequest.builder()
+                .specialtyId(specialtyId)
+                .region(region)
+                .search(search)
+                .sortBy(sortBy)
+                .sortOrder(sortOrder)
+                .build();
+
+        return trainerService.getTrainers(request, pageable);
+    }
+
+    // 특정 트레이너의 강의 목록 조회
+    @GetMapping("/{trainerId}/videos")
+    public Page<VideoResponse> getTrainerVideos(
+            @PathVariable Long trainerId,
+            @RequestParam(required = false) Integer page,
+            @RequestParam(required = false) Integer perPage,
+            @RequestParam(required = false) Long categoryId,
+            @RequestParam(required = false) String search
+    ) {
+        int p = (page == null || page < 1) ? 0 : page - 1;
+        int size = (perPage == null) ? 20 : Math.min(perPage, 100);
+
+        Sort sort = Sort.by("uploadTime").descending();
+        Pageable pageable = PageRequest.of(p, size, sort);
+
+        VideoSearchRequest request = VideoSearchRequest.builder()
+                .trainerId(trainerId)
+                .categoryId(categoryId)
+                .search(search)
+                .build();
+
+        return videoService.getVideos(request, pageable);
     }
 
     // 트레이너 정보 수정

--- a/src/main/java/com/fightingkorea/platform/domain/trainer/dto/TrainerSearchRequest.java
+++ b/src/main/java/com/fightingkorea/platform/domain/trainer/dto/TrainerSearchRequest.java
@@ -1,0 +1,18 @@
+package com.fightingkorea.platform.domain.trainer.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TrainerSearchRequest {
+    private Long specialtyId;
+    private String region;
+    private String search;
+    private String sortBy;
+    private String sortOrder;
+}

--- a/src/main/java/com/fightingkorea/platform/domain/trainer/repository/CustomTrainerRepository.java
+++ b/src/main/java/com/fightingkorea/platform/domain/trainer/repository/CustomTrainerRepository.java
@@ -1,9 +1,10 @@
 package com.fightingkorea.platform.domain.trainer.repository;
 
 import com.fightingkorea.platform.domain.trainer.dto.TrainerResponse;
+import com.fightingkorea.platform.domain.trainer.dto.TrainerSearchRequest;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomTrainerRepository {
-    PageImpl<TrainerResponse> findBySomeCondition(Pageable pageable);
+    PageImpl<TrainerResponse> search(TrainerSearchRequest request, Pageable pageable);
 }

--- a/src/main/java/com/fightingkorea/platform/domain/trainer/repository/impl/CustomTrainerRepositoryImpl.java
+++ b/src/main/java/com/fightingkorea/platform/domain/trainer/repository/impl/CustomTrainerRepositoryImpl.java
@@ -1,10 +1,16 @@
 package com.fightingkorea.platform.domain.trainer.repository.impl;
 
 import com.fightingkorea.platform.domain.trainer.dto.TrainerResponse;
+import com.fightingkorea.platform.domain.trainer.dto.TrainerSearchRequest;
 import com.fightingkorea.platform.domain.trainer.entity.QTrainer;
+import com.fightingkorea.platform.domain.trainer.entity.QTrainerSpecialty;
 import com.fightingkorea.platform.domain.trainer.repository.CustomTrainerRepository;
 import com.fightingkorea.platform.domain.user.dto.UserResponse;
 import com.fightingkorea.platform.domain.user.entity.QUser;
+import com.fightingkorea.platform.domain.video.entity.QVideo;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -22,9 +28,35 @@ public class CustomTrainerRepositoryImpl implements CustomTrainerRepository {
 
     QTrainer trainer = QTrainer.trainer;
     QUser user = QUser.user;
+    QTrainerSpecialty trainerSpecialty = QTrainerSpecialty.trainerSpecialty;
+    QVideo video = QVideo.video;
 
     @Override
-    public PageImpl<TrainerResponse> findBySomeCondition(Pageable pageable) {
+    public PageImpl<TrainerResponse> search(TrainerSearchRequest request, Pageable pageable) {
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(user.isActive.eq(true));
+
+        if (request.getRegion() != null) {
+            builder.and(user.region.eq(request.getRegion()));
+        }
+
+        if (request.getSearch() != null) {
+            builder.and(user.nickname.containsIgnoreCase(request.getSearch())
+                    .or(trainer.bio.containsIgnoreCase(request.getSearch())));
+        }
+
+        if (request.getSpecialtyId() != null) {
+            builder.and(trainerSpecialty.specialtyId.eq(request.getSpecialtyId()));
+        }
+
+        Order order = "asc".equalsIgnoreCase(request.getSortOrder()) ? Order.ASC : Order.DESC;
+        OrderSpecifier<?> orderSpecifier;
+        if ("videoCount".equalsIgnoreCase(request.getSortBy())) {
+            orderSpecifier = new OrderSpecifier<>(order, video.count());
+        } else {
+            orderSpecifier = new OrderSpecifier<>(order, user.createdAt);
+        }
+
         List<TrainerResponse> contents = queryFactory
                 .select(Projections.constructor(TrainerResponse.class,
                         trainer.trainerId,
@@ -34,24 +66,30 @@ public class CustomTrainerRepositoryImpl implements CustomTrainerRepository {
                         trainer.automaticSettlement,
                         trainer.charge,
                         Projections.constructor(UserResponse.class,
-                                trainer.user.userId,
-                                trainer.user.nickname,
-                                trainer.user.role,
-                                trainer.user.createdAt
+                                user.userId,
+                                user.nickname,
+                                user.role,
+                                user.createdAt
                         )
                 ))
                 .from(trainer)
                 .join(trainer.user, user)
-                .where(trainer.user.isActive.eq(true))
-                .orderBy(trainer.user.createdAt.desc())
-                .offset((long) pageable.getPageNumber() * pageable.getPageSize())
+                .leftJoin(trainerSpecialty).on(trainerSpecialty.trainerId.eq(trainer.trainerId))
+                .leftJoin(trainer.videos, video)
+                .where(builder)
+                .groupBy(trainer.trainerId)
+                .orderBy(orderSpecifier)
+                .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
         Long total = queryFactory
-                .select(trainer.count())
+                .select(trainer.trainerId.countDistinct())
                 .from(trainer)
-                .where(trainer.user.isActive.eq(true))
+                .join(trainer.user, user)
+                .leftJoin(trainerSpecialty).on(trainerSpecialty.trainerId.eq(trainer.trainerId))
+                .leftJoin(trainer.videos, video)
+                .where(builder)
                 .fetchOne();
 
         return new PageImpl<>(contents, pageable, total);

--- a/src/main/java/com/fightingkorea/platform/domain/trainer/service/TrainerService.java
+++ b/src/main/java/com/fightingkorea/platform/domain/trainer/service/TrainerService.java
@@ -1,9 +1,6 @@
 package com.fightingkorea.platform.domain.trainer.service;
 
-import com.fightingkorea.platform.domain.trainer.dto.TrainerRegisterRequest;
-import com.fightingkorea.platform.domain.trainer.dto.TrainerRegisterResponse;
-import com.fightingkorea.platform.domain.trainer.dto.TrainerResponse;
-import com.fightingkorea.platform.domain.trainer.dto.TrainerUpdateRequest;
+import com.fightingkorea.platform.domain.trainer.dto.*;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
@@ -12,7 +9,7 @@ public interface TrainerService {
 
     TrainerResponse getTrainer(Long trainerId);
 
-    PageImpl<TrainerResponse> getTrainers(Pageable pageable);
+    PageImpl<TrainerResponse> getTrainers(TrainerSearchRequest request, Pageable pageable);
 
     void updateTrainer(TrainerUpdateRequest trainerUpdateRequest);
 }

--- a/src/main/java/com/fightingkorea/platform/domain/trainer/service/impl/TrainerServiceImpl.java
+++ b/src/main/java/com/fightingkorea/platform/domain/trainer/service/impl/TrainerServiceImpl.java
@@ -1,9 +1,6 @@
 package com.fightingkorea.platform.domain.trainer.service.impl;
 
-import com.fightingkorea.platform.domain.trainer.dto.TrainerRegisterRequest;
-import com.fightingkorea.platform.domain.trainer.dto.TrainerRegisterResponse;
-import com.fightingkorea.platform.domain.trainer.dto.TrainerResponse;
-import com.fightingkorea.platform.domain.trainer.dto.TrainerUpdateRequest;
+import com.fightingkorea.platform.domain.trainer.dto.*;
 import com.fightingkorea.platform.domain.trainer.entity.Trainer;
 import com.fightingkorea.platform.domain.trainer.entity.TrainerSpecialty;
 import com.fightingkorea.platform.domain.trainer.exception.TrainerNotFoundException;
@@ -88,10 +85,10 @@ public class TrainerServiceImpl implements TrainerService {
     // 페이징된 트레이너 리스트 조회
     @Transactional(readOnly = true)
     @Override
-    public PageImpl<TrainerResponse> getTrainers(Pageable pageable) {
+    public PageImpl<TrainerResponse> getTrainers(TrainerSearchRequest request, Pageable pageable) {
         log.info("트레이너 목록 조회 요청, 페이지 번호: {}, 페이지 크기: {}", pageable.getPageNumber(), pageable.getPageSize());
 
-        PageImpl<TrainerResponse> result = trainerRepository.findBySomeCondition(pageable);
+        PageImpl<TrainerResponse> result = trainerRepository.search(request, pageable);
 
         log.info("트레이너 목록 조회 완료, 조회 수: {}", result.getNumberOfElements());
 

--- a/src/main/java/com/fightingkorea/platform/domain/user/controller/UserController.java
+++ b/src/main/java/com/fightingkorea/platform/domain/user/controller/UserController.java
@@ -8,11 +8,13 @@ import com.fightingkorea.platform.domain.user.entity.User;
 import com.fightingkorea.platform.domain.user.entity.type.Role;
 import com.fightingkorea.platform.domain.user.entity.type.Sex;
 import com.fightingkorea.platform.domain.user.service.UserService;
+import com.fightingkorea.platform.domain.video.dto.PurchaseSearchRequest;
 import com.fightingkorea.platform.domain.video.dto.UserVideoResponse;
 import com.fightingkorea.platform.domain.video.service.VideoService;
 import com.fightingkorea.platform.global.UserUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -126,9 +128,26 @@ public class UserController {
     // 현재 로그인한 사용자의 강의 구매 목록 조회 (사양 경로)
     @GetMapping("/me/purchases")
     public Page<UserVideoResponse> getMyPurchasedVideos(
-            @PageableDefault(size = 10, sort = "purchasedAt", direction = Sort.Direction.DESC) Pageable pageable
+            @RequestParam(required = false) Integer page,
+            @RequestParam(required = false) Integer perPage,
+            @RequestParam(required = false) Long categoryId,
+            @RequestParam(required = false) String search,
+            @RequestParam(required = false, defaultValue = "purchaseDate") String sortBy,
+            @RequestParam(required = false, defaultValue = "desc") String sortOrder
     ) {
-        return videoService.getPurchasedVideoList(UserUtil.getUserId(), pageable);
+        int p = (page == null || page < 1) ? 0 : page - 1;
+        int size = (perPage == null) ? 20 : Math.min(perPage, 100);
+
+        Pageable pageable = PageRequest.of(p, size);
+
+        PurchaseSearchRequest request = PurchaseSearchRequest.builder()
+                .categoryId(categoryId)
+                .search(search)
+                .sortBy(sortBy)
+                .sortOrder(sortOrder)
+                .build();
+
+        return videoService.getPurchasedVideoList(UserUtil.getUserId(), request, pageable);
     }
 
 

--- a/src/main/java/com/fightingkorea/platform/domain/video/dto/PurchaseSearchRequest.java
+++ b/src/main/java/com/fightingkorea/platform/domain/video/dto/PurchaseSearchRequest.java
@@ -1,0 +1,17 @@
+package com.fightingkorea.platform.domain.video.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PurchaseSearchRequest {
+    private Long categoryId; // 카테고리 ID
+    private String search;   // 제목 검색어
+    private String sortBy;   // purchaseDate, title
+    private String sortOrder; // asc, desc
+}

--- a/src/main/java/com/fightingkorea/platform/domain/video/dto/UserVideoResponse.java
+++ b/src/main/java/com/fightingkorea/platform/domain/video/dto/UserVideoResponse.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class UserVideoResponse {
 
+    private Long purchaseId; // 구매 아이디
     private Long videoId; // 비디오 아이디
 
     private String title; // 비디오 제목

--- a/src/main/java/com/fightingkorea/platform/domain/video/dto/VideoSearchRequest.java
+++ b/src/main/java/com/fightingkorea/platform/domain/video/dto/VideoSearchRequest.java
@@ -1,0 +1,21 @@
+package com.fightingkorea.platform.domain.video.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class VideoSearchRequest {
+    private Long categoryId;
+    private Long trainerId;
+    private String search;
+    private Integer minPrice;
+    private Integer maxPrice;
+}
+

--- a/src/main/java/com/fightingkorea/platform/domain/video/entity/Video.java
+++ b/src/main/java/com/fightingkorea/platform/domain/video/entity/Video.java
@@ -1,12 +1,13 @@
 package com.fightingkorea.platform.domain.video.entity;
 
 import com.fightingkorea.platform.domain.trainer.entity.Trainer;
-
 import jakarta.persistence.*;
-
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
 
 @Entity
 @Table(name = "videos")
@@ -46,6 +47,9 @@ public class Video {
 
     @Column
     private Integer likesCount; // 좋아요
+
+    @OneToMany(mappedBy = "video", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<VideoCategory> videoCategories = new ArrayList<>();
 
     public static Video createVideoFromMultipart(com.fightingkorea.platform.domain.video.dto.VideoUploadMultipartRequest req, Trainer trainer, String s3Key) {
         return Video

--- a/src/main/java/com/fightingkorea/platform/domain/video/repository/CustomUserVideoRepository.java
+++ b/src/main/java/com/fightingkorea/platform/domain/video/repository/CustomUserVideoRepository.java
@@ -1,11 +1,12 @@
 package com.fightingkorea.platform.domain.video.repository;
 
+import com.fightingkorea.platform.domain.video.dto.PurchaseSearchRequest;
 import com.fightingkorea.platform.domain.video.dto.UserVideoResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomUserVideoRepository {
 
-    Page<UserVideoResponse> getPurchasedVideoList(Long userId, Pageable pageable);
+    Page<UserVideoResponse> getPurchasedVideoList(Long userId, PurchaseSearchRequest request, Pageable pageable);
 
 }

--- a/src/main/java/com/fightingkorea/platform/domain/video/repository/Impl/CustomUserVideoRepositoryImpl.java
+++ b/src/main/java/com/fightingkorea/platform/domain/video/repository/Impl/CustomUserVideoRepositoryImpl.java
@@ -1,10 +1,15 @@
 package com.fightingkorea.platform.domain.video.repository.Impl;
 
+import com.fightingkorea.platform.domain.video.dto.PurchaseSearchRequest;
 import com.fightingkorea.platform.domain.video.dto.UserVideoResponse;
 import com.fightingkorea.platform.domain.video.entity.QUserVideo;
 import com.fightingkorea.platform.domain.video.entity.QVideo;
+import com.fightingkorea.platform.domain.video.entity.QVideoCategory;
 import com.fightingkorea.platform.domain.video.repository.CustomUserVideoRepository;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -25,28 +30,57 @@ public class CustomUserVideoRepositoryImpl implements CustomUserVideoRepository{
     QVideo video = QVideo.video;
 
     @Override
-    public Page<UserVideoResponse> getPurchasedVideoList(Long userId, Pageable pageable){
+    public Page<UserVideoResponse> getPurchasedVideoList(Long userId, PurchaseSearchRequest request, Pageable pageable){
 
-        List<UserVideoResponse> contents = queryFactory
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(userVideo.user.userId.eq(userId));
+        if (request.getSearch() != null && !request.getSearch().isEmpty()) {
+            builder.and(video.title.containsIgnoreCase(request.getSearch()));
+        }
+
+        JPAQuery<UserVideoResponse> contentQuery = queryFactory
                 .select(Projections.constructor(UserVideoResponse.class,
+                        userVideo.userVideoId,
                         video.videoId,
                         video.title,
                         userVideo.purchasePrice,
                         userVideo.purchasedAt
                 ))
                 .from(userVideo)
-                .join(userVideo.video, video)
-                .where(userVideo.user.userId.eq(userId))
-                .orderBy(userVideo.purchasedAt.desc())
+                .join(userVideo.video, video);
+
+        JPAQuery<Long> countQuery = queryFactory
+                .select(userVideo.count())
+                .from(userVideo)
+                .join(userVideo.video, video);
+
+        if (request.getCategoryId() != null) {
+            QVideoCategory vc = QVideoCategory.videoCategory;
+            contentQuery.join(video.videoCategories, vc)
+                    .where(vc.categoryId.eq(request.getCategoryId()));
+            countQuery.join(video.videoCategories, vc)
+                    .where(vc.categoryId.eq(request.getCategoryId()));
+        }
+
+        contentQuery.where(builder);
+        countQuery.where(builder);
+
+        String sortBy = request.getSortBy() == null ? "purchaseDate" : request.getSortBy();
+        boolean asc = "asc".equalsIgnoreCase(request.getSortOrder());
+        OrderSpecifier<?> order;
+        if ("title".equals(sortBy)) {
+            order = asc ? video.title.asc() : video.title.desc();
+        } else {
+            order = asc ? userVideo.purchasedAt.asc() : userVideo.purchasedAt.desc();
+        }
+
+        List<UserVideoResponse> contents = contentQuery
+                .orderBy(order)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        Long total = queryFactory
-                .select(userVideo.count())
-                .from(userVideo)
-                .where(userVideo.user.userId.eq(userId))
-                .fetchOne();
+        Long total = countQuery.fetchOne();
 
         return new PageImpl<>(contents, pageable, total);
     }

--- a/src/main/java/com/fightingkorea/platform/domain/video/repository/VideoRepository.java
+++ b/src/main/java/com/fightingkorea/platform/domain/video/repository/VideoRepository.java
@@ -2,10 +2,11 @@ package com.fightingkorea.platform.domain.video.repository;
 
 import com.fightingkorea.platform.domain.video.entity.Video;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 import java.util.Optional;
 
-public interface VideoRepository extends JpaRepository<Video, Long> {
+public interface VideoRepository extends JpaRepository<Video, Long>, JpaSpecificationExecutor<Video> {
 
     Boolean existsByTitle(String title);
 

--- a/src/main/java/com/fightingkorea/platform/domain/video/service/Impl/VideoServiceImpl.java
+++ b/src/main/java/com/fightingkorea/platform/domain/video/service/Impl/VideoServiceImpl.java
@@ -6,6 +6,7 @@ import com.fightingkorea.platform.domain.trainer.repository.TrainerRepository;
 import com.fightingkorea.platform.domain.video.dto.*;
 import com.fightingkorea.platform.domain.video.entity.UserVideo;
 import com.fightingkorea.platform.domain.video.entity.Video;
+import com.fightingkorea.platform.domain.video.entity.VideoCategory;
 import com.fightingkorea.platform.domain.video.exception.*;
 import com.fightingkorea.platform.domain.video.repository.UserVideoRepository;
 import com.fightingkorea.platform.domain.video.repository.VideoRepository;
@@ -18,6 +19,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.JoinType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -41,8 +45,37 @@ public class VideoServiceImpl implements VideoService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<VideoResponse> getVideos(Pageable pageable) {
-        return videoRepository.findAll(pageable).map(this::toDtoWithNoLink);
+    public Page<VideoResponse> getVideos(VideoSearchRequest request, Pageable pageable) {
+        Specification<Video> spec = Specification.where(null);
+
+        if (request.getTrainerId() != null) {
+            spec = spec.and((root, query, cb) -> cb.equal(root.get("trainer").get("trainerId"), request.getTrainerId()));
+        }
+
+        if (request.getSearch() != null && !request.getSearch().isBlank()) {
+            String like = "%" + request.getSearch() + "%";
+            spec = spec.and((root, query, cb) -> cb.or(
+                    cb.like(root.get("title"), like),
+                    cb.like(root.get("description"), like)
+            ));
+        }
+
+        if (request.getMinPrice() != null) {
+            spec = spec.and((root, query, cb) -> cb.greaterThanOrEqualTo(root.get("price"), request.getMinPrice()));
+        }
+
+        if (request.getMaxPrice() != null) {
+            spec = spec.and((root, query, cb) -> cb.lessThanOrEqualTo(root.get("price"), request.getMaxPrice()));
+        }
+
+        if (request.getCategoryId() != null) {
+            spec = spec.and((root, query, cb) -> {
+                Join<Video, VideoCategory> join = root.join("videoCategories", JoinType.INNER);
+                return cb.equal(join.get("categoryId"), request.getCategoryId());
+            });
+        }
+
+        return videoRepository.findAll(spec, pageable).map(this::toDtoWithNoLink);
     }
 
     @Override
@@ -93,11 +126,11 @@ public class VideoServiceImpl implements VideoService {
     // 비디오 목록, 유저의 비디오 소유 목록
     @Transactional(readOnly = true)
     @Override
-    public Page<UserVideoResponse> getPurchasedVideoList(Long userId, Pageable pageable) {
+    public Page<UserVideoResponse> getPurchasedVideoList(Long userId, PurchaseSearchRequest request, Pageable pageable) {
 
         log.info("강의 구매 목록 조회 시도: userId={}", UserUtil.getUserId());
 
-        Page<UserVideoResponse> userVideoResponses = userVideoRepository.getPurchasedVideoList(userId, pageable);
+        Page<UserVideoResponse> userVideoResponses = userVideoRepository.getPurchasedVideoList(userId, request, pageable);
 
         if (userVideoResponses.isEmpty()) {
             log.info("userId{} 가 구매한 강의 없음", userId);

--- a/src/main/java/com/fightingkorea/platform/domain/video/service/VideoService.java
+++ b/src/main/java/com/fightingkorea/platform/domain/video/service/VideoService.java
@@ -7,8 +7,8 @@ import org.springframework.data.domain.Pageable;
 public interface VideoService {
 
 
-    // 비디오 목록 조회 (페이징)
-    Page<VideoResponse> getVideos(Pageable pageable);
+    // 비디오 목록 조회 (필터링 및 페이징)
+    Page<VideoResponse> getVideos(VideoSearchRequest request, Pageable pageable);
     
 
     VideoResponse updateVideo(Long videoId, VideoUpdateRequest req);
@@ -16,7 +16,7 @@ public interface VideoService {
     void deleteVideo(Long videoId);
 
     // 페이징된 특정 유저의 강의 구매 리스트 조회
-    Page<UserVideoResponse> getPurchasedVideoList(Long userId, Pageable pageable);
+    Page<UserVideoResponse> getPurchasedVideoList(Long userId, PurchaseSearchRequest request, Pageable pageable);
 
     VideoResponse uploadVideoMultipart(VideoUploadMultipartRequest req, org.springframework.web.multipart.MultipartFile file);
 


### PR DESCRIPTION
## Summary
- support flexible filtering and sorting for video list API
- add TrainerSearchRequest and enhance /api/trainers to filter by specialty, region, search term, and sort order
- implement QueryDSL repository logic for trainer search with dynamic criteria
- expose /api/trainers/{trainerId}/videos for listing a trainer's uploaded videos
- enable `/api/users/me/purchases` to filter, sort, and paginate purchased videos

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c77dd0008322a87700baeb1cce7d